### PR TITLE
Removed portside.social

### DIFF
--- a/spam/2024-02-15/2024-02-15-spam-domain_mutes-erik-uden.csv
+++ b/spam/2024-02-15/2024-02-15-spam-domain_mutes-erik-uden.csv
@@ -66,7 +66,6 @@
 "onlybsds.com","silence","true","false","Spam (2024-02-15)","false"
 "owo.town","silence","true","false","Spam (2024-02-15)","false"
 "phyrexia.ru","silence","true","false","Spam (2024-02-15)","false"
-"portside.social","silence","true","false","Spam (2024-02-15)","false"
 "pouet.evolix.org","silence","true","false","Spam (2024-02-15)","false"
 "quakers.social","silence","true","false","Spam (2024-02-15)","false"
 "rope-access-work.com","silence","true","false","Spam (2024-02-15)","false"


### PR DESCRIPTION
Removed portside.social since it has fixed its spam issues and is now a threat level 0.